### PR TITLE
Update the examples for recent bigrquery changes.

### DIFF
--- a/1000genomes/README.Rmd
+++ b/1000genomes/README.Rmd
@@ -36,12 +36,11 @@ require(ggplot2)
 require(dplyr)
 require(xtable)
 require(testthat)
-billing_project <- "google.com:biggene" # put your projectID here
+project <- "google.com:biggene" # put your projectID here
 DisplayAndDispatchQuery <- function(queryUri) {
   sql <- readChar(queryUri, nchars=1e6)
   cat(sql)
-  query_exec(project="google.com:biggene", dataset="1000genomes",
-                    query=sql, billing=billing_project)  
+  query_exec(sql, project)
 }
 ```
 
@@ -56,11 +55,11 @@ print(xtable(result, digits=6), type="html", include.rownames=F)
 
 And visually:
 ```{r dbSNP Variants, echo=FALSE, message=FALSE, warning=FALSE, comment=NA, fig.align="center", fig.width=12, fig.height=8}
-qplot(num_variants, num_dbsnp_variants, color=num_variants, data=result) + 
+qplot(num_variants, num_dbsnp_variants, color=num_variants, data=result) +
   scale_colour_gradient("Number of Variants", labels=function(x)round(x)) +
-  ylab("Number of dbSNP Variants") + 
-  xlab("Number of Variants") + 
-  ggtitle("dbSNP Variant Count vs. Total Variant Count by Chromosome") + 
+  ylab("Number of dbSNP Variants") +
+  xlab("Number of Variants") +
+  ggtitle("dbSNP Variant Count vs. Total Variant Count by Chromosome") +
   geom_text(aes(label=contig), hjust=-1, vjust=0)
 ```
 
@@ -112,7 +111,7 @@ print(xtable(tail(result)), type="html", include.rownames=F)
 ```
 And visually:
 ```{r shared Variants, echo=FALSE, message=FALSE, warning=FALSE, comment=NA, fig.align="center", fig.width=12, fig.height=8}
-ggplot(result, aes(x=num_samples_with_variant, 
+ggplot(result, aes(x=num_samples_with_variant,
                   y=num_variants_shared_by_this_many_samples)) +
   geom_point() +
   scale_y_log10() +
@@ -134,9 +133,9 @@ Number of rows returned by this query: `r nrow(result)`.
 
 ```{r sanity check, echo=FALSE, message=FALSE, warning=FALSE, comment=NA}
 # Check that the query logic was correct
-expect_equal(object=sum(as.numeric(result$num_samples_in_pop_with_variant_in_category * 
-                                   result$num_variants_shared_by_this_many_samples)), 
-             expected=sum(as.numeric(sharedVars$num_samples_with_variant * 
+expect_equal(object=sum(as.numeric(result$num_samples_in_pop_with_variant_in_category *
+                                   result$num_variants_shared_by_this_many_samples)),
+             expected=sum(as.numeric(sharedVars$num_samples_with_variant *
                                      sharedVars$num_variants_shared_by_this_many_samples)))
 # Coerce the variant type to logical so that we can use it for categorization in plots
 result$is_common_variant <- as.logical(result$is_common_variant)
@@ -151,7 +150,7 @@ print(xtable(tail(result)), type="html", include.rownames=F)
 ```
 
 ```{r shared variants by pop, echo=FALSE, message=FALSE, warning=FALSE, comment=NA, fig.align="center", fig.width=12, fig.height=8}
-ggplot(result, aes(x=num_samples_in_pop_with_variant_in_category, 
+ggplot(result, aes(x=num_samples_in_pop_with_variant_in_category,
                    y=num_variants_shared_by_this_many_samples,
                    color=super_population,
                    shape=is_common_variant)) +
@@ -163,12 +162,12 @@ ggplot(result, aes(x=num_samples_in_pop_with_variant_in_category,
                 "Number of variants having a non-reference allele in 0, 1, 2, etc... samples",
                 sep="\n"))
 ```
-The plot is interesting but a little too busy.  Let us break it down into 
-separate plots for common and rare variants.  
+The plot is interesting but a little too busy.  Let us break it down into
+separate plots for common and rare variants.
 
 First, common variants:
 ```{r shared common variants by pop, echo=FALSE, message=FALSE, warning=FALSE, comment=NA, fig.align="center", fig.width=12, fig.height=8}
-ggplot(filter(result, is_common_variant == TRUE), aes(x=num_samples_in_pop_with_variant_in_category, 
+ggplot(filter(result, is_common_variant == TRUE), aes(x=num_samples_in_pop_with_variant_in_category,
                    y=num_variants_shared_by_this_many_samples,
                    color=super_population,
                    shape=is_common_variant)) +
@@ -182,7 +181,7 @@ ggplot(filter(result, is_common_variant == TRUE), aes(x=num_samples_in_pop_with_
 ```
 There seems to be some interesting shape to this plot, but the sample counts are a little misleading since the number of samples within each super population is not the same.  Let us normalize by total number of samples in each super population group.
 ```{r shared common variants by percent pop, echo=FALSE, message=FALSE, warning=FALSE, comment=NA, fig.align="center", fig.width=12, fig.height=8}
-ggplot(filter(result, is_common_variant == TRUE), aes(x=percent_samples_in_pop_with_variant_in_category, 
+ggplot(filter(result, is_common_variant == TRUE), aes(x=percent_samples_in_pop_with_variant_in_category,
                    y=num_variants_shared_by_this_many_samples,
                    color=super_population,
                    shape=is_common_variant)) +
@@ -198,8 +197,8 @@ Its interesting to see that the Asian superpopulation has both the most variants
 
 And now for rare variants:
 ```{r shared rare variants by pop, echo=FALSE, message=FALSE, warning=FALSE, comment=NA, fig.align="center", fig.width=12, fig.height=8}
-ggplot(filter(result, is_common_variant == FALSE), 
-       aes(x=num_samples_in_pop_with_variant_in_category, 
+ggplot(filter(result, is_common_variant == FALSE),
+       aes(x=num_samples_in_pop_with_variant_in_category,
            y=num_variants_shared_by_this_many_samples,
            color=super_population,
            shape=is_common_variant)) +
@@ -213,8 +212,8 @@ ggplot(filter(result, is_common_variant == FALSE),
 ```
 Again, normalizing by population size:
 ```{r shared rare variants by percent pop, echo=FALSE, message=FALSE, warning=FALSE, comment=NA, fig.align="center", fig.width=12, fig.height=8}
-ggplot(filter(result, is_common_variant == FALSE), 
-       aes(x=percent_samples_in_pop_with_variant_in_category, 
+ggplot(filter(result, is_common_variant == FALSE),
+       aes(x=percent_samples_in_pop_with_variant_in_category,
            y=num_variants_shared_by_this_many_samples,
            color=super_population,
            shape=is_common_variant)) +

--- a/1000genomes/data-stories/annotation-joins/README.Rmd
+++ b/1000genomes/data-stories/annotation-joins/README.Rmd
@@ -24,18 +24,16 @@ require(bigrquery)
 require(ggplot2)
 require(xtable)
 require(testthat)
-billing_project <- "google.com:biggene" # put your projectID here
+project <- "google.com:biggene" # put your projectID here
 ```
 
 Let us start by getting an idea of the number of rows in each of our tables.
 ```{r cache=TRUE}
 tables <- c("variants1kG", "pedigree", "sample_info", "clinvar", "clinvar_disease_names", "known_genes", "known_genes_aliases")
 lapply(tables, function(table) {
-  result <- query_exec(project="google.com:biggene", 
-                      dataset="1000genomes", 
-                      query=paste("SELECT count(*) AS cnt FROM [google.com:biggene:1000genomes.", 
-                                  table, "]", sep=""),
-                      billing=billing_project)
+  sql <- paste0("SELECT count(*) AS cnt FROM [google.com:biggene:1000genomes.",
+                table, "]")
+  result <- query_exec(sql, project)
   paste(table, result, sep=": ")
 })
 ```
@@ -43,8 +41,8 @@ We can see that all the annotation databases are dwarfed in size by the data in 
 
 Let us also examine the types of variants within ClinVar.
 ```{r cache=TRUE}
-result <- query_exec(project="google.com:biggene", dataset="1000genomes",
-                    query="SELECT type, count(1) cnt FROM [1000genomes.clinvar] group by type", billing=billing_project)
+result <- query_exec("SELECT type, count(1) cnt FROM [google.com:biggene:1000genomes.clinvar] group by type",
+                     project)
 dim(result)
 ```
 Display the rows of our result
@@ -61,7 +59,7 @@ We can see that the vast majority of variants within ClinVar are SNPs.
 sql <- readChar("../../sql/individual-clinically-concerning-variants.sql",
                nchars=1e6)
 cat(sql)
-result <- query_exec(project="google.com:biggene", dataset="1000genomes", query=sql, billing=billing_project)
+result <- query_exec(sql, project)
 dim(result)
 ```
 Display the first few rows of our result
@@ -75,7 +73,7 @@ We can see that this indivudual has 53 clinically concerning variants.
 sql <- readChar("../../sql/familial-shared-clinically-concerning-variants.sql",
                nchars=1e6)
 cat(sql)
-result <- query_exec(project="google.com:biggene", dataset="1000genomes", query=sql, billing=billing_project)
+result <- query_exec(sql, project)
 dim(result)
 ```
 Display the first few rows of our result
@@ -88,9 +86,8 @@ We can see that some variants are shared by as many as four family members.
 
 First, let us see what the INDEL data looks like in ClinVar:
 ```{r cache=TRUE}
-result <- query_exec(project="google.com:biggene", dataset="1000genomes",
-                    query="SELECT * FROM [1000genomes.clinvar] where type="indel"", 
-                    billing=billing_project)
+sql <- 'SELECT * FROM [google.com:biggene:1000genomes.clinvar] where type="indel"'
+result <- query_exec(sql, project)
 dim(result)
 ```
 Display the firs few rows of our result
@@ -108,7 +105,7 @@ Next we will JOIN our variants with gene names.  Note that the JOIN criteria is 
 sql <- readChar("../../sql/gene-variant-counts.sql",
                nchars=1e6)
 cat(sql)
-result <- query_exec(project="google.com:biggene", dataset="1000genomes", query=sql, billing=billing_project)
+result <- query_exec(sql, project)
 dim(result)
 ```
 Display the first few rows of our result
@@ -133,7 +130,7 @@ Now let us look at these sample variants for a particular sample
 sql <- readChar("../../sql/sample-gene-variant-counts.sql",
                nchars=1e6)
 cat(sql)
-result <- query_exec(project="google.com:biggene", dataset="1000genomes", query=sql, billing=billing_project)
+result <- query_exec(sql, project)
 dim(result)
 ```
 Display the first few rows of our result
@@ -156,8 +153,8 @@ brca1_all$name == brca1_one$name
 expect_that(brca1_all$name, equals(brca1_one$name))
 brca1_all$cnt - brca1_one$cnt
 mean(brca1_all$cnt - brca1_one$cnt)
-qplot(brca1_all$cnt, brca1_one$cnt, 
-      xlim=c(0, max(brca1_all$cnt)), 
+qplot(brca1_all$cnt, brca1_one$cnt,
+      xlim=c(0, max(brca1_all$cnt)),
       ylim=c(0, max(brca1_all$cnt)),
       xlab="count of variants per gene for the full dataset",
       ylab="count of variants per gene for one sample",
@@ -171,7 +168,7 @@ Let us go bigger now and run this on the entire 1,000 Genomes dataset.
 sql <- readChar("../../sql/specific-gene-variant-counts.sql",
                nchars=1e6)
 cat(sql)
-result <- query_exec(project="google.com:biggene", dataset="1000genomes", query=sql, billing=billing_project)
+result <- query_exec(sql, project)
 dim(result)
 ```
 Display the rows of our result

--- a/1000genomes/data-stories/exploring-the-phenotypic-data/README.Rmd
+++ b/1000genomes/data-stories/exploring-the-phenotypic-data/README.Rmd
@@ -27,12 +27,11 @@ require(ggplot2)
 require(dplyr)
 require(xtable)
 require(testthat)
-billing_project <- "google.com:biggene" # put your projectID here
+project <- "google.com:biggene" # put your projectID here
 DisplayAndDispatchQuery <- function(queryUri) {
   sql <- readChar(queryUri, nchars=1e6)
   cat(sql)
-  query_exec(project="google.com:biggene", dataset="1000genomes",
-                    query=sql, billing=billing_project)  
+  query_exec(sql, project)
 }
 ```
 
@@ -48,11 +47,11 @@ print(xtable(head(result)), type="html", include.rownames=F)
 ```{r samples, echo=FALSE, message=FALSE, warning=FALSE, comment=NA, fig.align="center", fig.width=6, fig.height=4}
 sample_groups <- data.frame(names(result), t(result))
 colnames(sample_groups) <- c("group", "count")
-ggplot(sample_groups, aes(x=group, y=count, fill=group)) + 
+ggplot(sample_groups, aes(x=group, y=count, fill=group)) +
   geom_bar(stat="identity") +
   scale_fill_discrete("Sample Groups", labels=c("All", "In BigQuery")) +
-  ylab("Count of Samples") + 
-  xlab("Sample Groups") 
+  ylab("Count of Samples") +
+  xlab("Sample Groups")
 ```
 So for analyses across all samples upon table [variants1kG](https://bigquery.cloud.google.com/table/google.com:biggene:1000genomes.variants1kG?pli=1), the sample size is 1,092.
 
@@ -84,11 +83,11 @@ print(xtable(result), type="html", include.rownames=F)
 ```
 
 ```{r ethnicity, echo=FALSE, message=FALSE, warning=FALSE, comment=NA, fig.align="center", fig.width=12, fig.height=4}
-ggplot(result, aes(x=population, y=population_count, fill=super_population)) + 
+ggplot(result, aes(x=population, y=population_count, fill=super_population)) +
   geom_bar(stat="identity") +
   scale_fill_discrete("Super Population") +
-  ylab("Count of Samples in Population") + 
-  xlab("Populations") 
+  ylab("Count of Samples in Population") +
+  xlab("Populations")
 ```
 So for analyses across ethnicity, we see that our sample sizes will range from 55 to 100, with an outlier of 14.
 
@@ -122,10 +121,10 @@ print(xtable(head(result)), type="html", include.rownames=F)
 ```
 
 ```{r ethnicity and gender, echo=FALSE, message=FALSE, warning=FALSE, comment=NA, fig.align="center", fig.width=12, fig.height=4}
-ggplot(result, aes(x=population, y=population_count, fill=gender)) + 
+ggplot(result, aes(x=population, y=population_count, fill=gender)) +
   geom_bar(stat="identity", position="dodge") +
-  ylab("Count of Samples in Population") + 
-  xlab("Populations") 
+  ylab("Count of Samples in Population") +
+  xlab("Populations")
 ```
 So for analyses taking into account both ethnicity and gender, we are often near the boundary for small-sample significance tests.
 
@@ -142,7 +141,7 @@ ggplot(result, aes(x=family_size, y=num_families_of_size, color=num_families_of_
   geom_freqpoly(stat="identity") +
   #scale_y_log10() +
   scale_colour_gradient("Number of Famlies of Size", trans="log", labels=function(x)round(x)) +
-  xlab("Number of family members") + 
+  xlab("Number of family members") +
   ylab("Count of families of size")
 ```
 We see that roughly two thirds of the families are comprised of only one family member.

--- a/1000genomes/data-stories/exploring-the-variant-data/README.Rmd
+++ b/1000genomes/data-stories/exploring-the-variant-data/README.Rmd
@@ -29,12 +29,10 @@ pallette_fill = scale_fill_manual(values=cbPalette)
 pallette_colour = scale_colour_manual(values=cbPalette)
 
 # Run a query against BigQuery 1k genomes table
+project <- "google.com:biggene" # put your projectID here
 RunQuery <- function(sql) {
   cat(sql)
-  return(query_exec("google.com:biggene",
-                    "1000genomes",
-                    sql,
-                    billing="google.com:biggene"))
+  return(query_exec(sql, project))
 }
 
 # Examines the quality score distibution of each variant type.
@@ -303,7 +301,7 @@ plots <- MakePositionsPlot()
 CreateGriddedPlot(plots)
 ```
  * A basic sanity check
- 
+
  * Chromosomes 13,14,15,21,22 have abnormally high min positions.
  * Chromosome 7 has low min position.
  * Hard to sequence regions?
@@ -330,9 +328,9 @@ CreateGriddedPlot(plots)
 ```
  * Total count is #genomes * #SNPs.
  * Same data - two views
- 
+
  * Red bars denote no mutation - both alleles equal reference.
- 
+
  * Why are A -> C,C and A-> G,G likely, but not A -> C,G or A -> G,C?
 
  * Note that A & T rows are reverses of each other, as are C & G rows.
@@ -347,10 +345,10 @@ CreateGriddedPlot(plots)
 ```
  * +/-51 are over/under flow bins
  * -> Large tail of deletions
- 
+
  * Positive length = Insertion
  * Negative length = Deletion
- 
+
  * Drops off quickly.
 
 Quality score of calls (at least, of INDELs)
@@ -362,7 +360,7 @@ plots <- MakeQualityPlot()
 CreateGriddedPlot(plots)
 ```
 From the 1k genome docs:
-> phred-scaled quality score for the assertion made in ALT. i.e. -10log_10 prob(call in ALT is wrong). If ALT is ”.” (no variant) then this is -10log_10 p(variant), and if ALT is not ”.” this is -10log_10 p(no variant). High QUAL scores indicate high confidence calls. 
+> phred-scaled quality score for the assertion made in ALT. i.e. -10log_10 prob(call in ALT is wrong). If ALT is ”.” (no variant) then this is -10log_10 p(variant), and if ALT is not ”.” this is -10log_10 p(no variant). High QUAL scores indicate high confidence calls.
 
 From Broad Institute:
 > The Phred scaled probability that a REF/ALT polymorphism exists at this site given sequencing data. Because the Phred scale is -10 * log(1-p), a value of 10 indicates a 1 in 10 chance of error, while a 100 indicates a 1 in 10^10 chance. These values can grow very large when a large amount of NGS data is used for variant calling.

--- a/1000genomes/data-stories/literate-programming-demo/README.Rmd
+++ b/1000genomes/data-stories/literate-programming-demo/README.Rmd
@@ -37,7 +37,7 @@ plot(cars)
 Analysis
 --------------
 
-Now let us move onto [literate programming](http://en.wikipedia.org/wiki/Literate_programming) for [BigQuery](https://developers.google.com/bigquery/).  
+Now let us move onto [literate programming](http://en.wikipedia.org/wiki/Literate_programming) for [BigQuery](https://developers.google.com/bigquery/).
 
 If you have never used the [bigrquery](https://github.com/hadley/bigrquery) package before, you will likely need to do something like the following to get it installed:
 
@@ -65,8 +65,8 @@ cat(sql)
 
 We will execute our query, bringing the results down to our R session for further examination:
 ```{r exec}
-billing_project <- "google.com:biggene" # put your projectID here
-result <- query_exec(project="google.com:biggene", dataset="1000genomes", query=sql, billing=billing_project)
+project <- "google.com:biggene" # put your projectID here
+result <- query_exec(sql, project)
 ```
 
 Let us examine our query result:

--- a/1000genomes/data-stories/reproducing-allelic-frequencies/README.Rmd
+++ b/1000genomes/data-stories/reproducing-allelic-frequencies/README.Rmd
@@ -25,12 +25,11 @@ require(ggplot2)
 require(dplyr)
 require(xtable)
 require(testthat)
-billing_project <- "google.com:biggene" # put your projectID here
+project <- "google.com:biggene" # put your projectID here
 DisplayAndDispatchQuery <- function(queryUri) {
   sql <- readChar(queryUri, nchars=1e6)
   cat(sql)
-  query_exec(project="google.com:biggene", dataset="1000genomes",
-                    query=sql, billing=billing_project)  
+  query_exec(sql, project)
 }
 ```
 
@@ -109,4 +108,3 @@ We see that the genders are quite close in their rate of variation.
 ```{r viz maf no X, echo=FALSE, fig.align="center", fig.width=12, fig.height=8}
 ggplot(result, aes(x=super_population, y=common_variant, fill=gender)) + geom_boxplot() + ylab("Count of common variants per sample") + ggtitle("Common Variants (Minimum Allelic Frequency 5%)")
 ```
-

--- a/1000genomes/data-stories/reproducing-hardy-weinberg-equilibrium/README.Rmd
+++ b/1000genomes/data-stories/reproducing-hardy-weinberg-equilibrium/README.Rmd
@@ -56,10 +56,10 @@ vcftools --vcf brca1.recode.vcf --hardy
 Producing output file: [out.hwe](./vcftools-output/out.hwe)
 
 See [details](http://vcftools.sourceforge.net/man_latest.html#OUTPUT OPTIONS) about the --hardy option for vcftools for more detail about the calculaton.
- 
+
 Reproducing the result via BigQuery
 ------------------------------------
-[BRCA1](http://www.genecards.org/cgi-bin/carddisp.pl?gene=BRCA1) resides on chromosome 17 from position 41196312 to 41277500.  
+[BRCA1](http://www.genecards.org/cgi-bin/carddisp.pl?gene=BRCA1) resides on chromosome 17 from position 41196312 to 41277500.
 
 ```{r init, echo=FALSE, message=FALSE, warning=FALSE, comment=NA}
 require(bigrquery)
@@ -67,12 +67,11 @@ require(ggplot2)
 require(dplyr)
 require(xtable)
 require(testthat)
-billing_project <- "google.com:biggene" # put your projectID here
+project <- "google.com:biggene" # put your projectID here
 DisplayAndDispatchQuery <- function(queryUri) {
   sql <- readChar(queryUri, nchars=1e6)
   cat(sql)
-  query_exec(project="google.com:biggene", dataset="1000genomes",
-                    query=sql, billing=billing_project)  
+  query_exec(sql, project)
 }
 ```
 
@@ -91,4 +90,3 @@ and the last few rows:
 print(tail(xtable(result), 10), type="html", include.rownames=F)
 ```
 Comparing these to the results in [out.hwe](./vcftools-output/out.hwe) from vcftools we see that the test scores match.
-

--- a/1000genomes/data-stories/reproducing-vcfstats/README.Rmd
+++ b/1000genomes/data-stories/reproducing-vcfstats/README.Rmd
@@ -65,10 +65,10 @@ Producing output files:
  * [shared](./vcfstats-output/stats.shared)
  * [snps](./vcfstats-output/stats.snps)
  * [tstv](./vcfstats-output/stats.tstv)
- 
+
 Reproducing the result via BigQuery
 ------------------------------------
-[BRCA1](http://www.genecards.org/cgi-bin/carddisp.pl?gene=BRCA1) resides on chromosome 17 from position 41196312 to 41277500.  
+[BRCA1](http://www.genecards.org/cgi-bin/carddisp.pl?gene=BRCA1) resides on chromosome 17 from position 41196312 to 41277500.
 
 ```{r init, echo=FALSE, message=FALSE, warning=FALSE, comment=NA}
 require(bigrquery)
@@ -76,12 +76,11 @@ require(ggplot2)
 require(dplyr)
 require(xtable)
 require(testthat)
-billing_project <- "google.com:biggene" # put your projectID here
+project <- "google.com:biggene" # put your projectID here
 DisplayAndDispatchQuery <- function(queryUri) {
   sql <- readChar(queryUri, nchars=1e6)
   cat(sql)
-  query_exec(project="google.com:biggene", dataset="1000genomes",
-                    query=sql, billing=billing_project)  
+  query_exec(sql, project)
 }
 ```
 
@@ -92,7 +91,7 @@ result <- DisplayAndDispatchQuery("../../sql/reproducing-vcfstats/variant-count-
 ```{r echo=FALSE, message=FALSE, warning=FALSE, comment=NA, results="asis"}
 print(xtable(result), type="html", include.rownames=F)
 ```
-We see that there are 879 variants on the BRCA1 gene in this dataset (equivalent to vcf-stats [dump-all](./vcfstats-output/stats.dump-all) entry all=>count). 
+We see that there are 879 variants on the BRCA1 gene in this dataset (equivalent to vcf-stats [dump-all](./vcfstats-output/stats.dump-all) entry all=>count).
 
 Let’s characterize the variants further by type.
 ```{r echo=FALSE, message=FALSE, warning=FALSE, comment=NA}
@@ -103,7 +102,7 @@ print(xtable(result), type="html", include.rownames=F)
 ```
 The majority are SNPs but some are INDELs (equivalent to vcf-stats [dump-all](./vcfstats-output/stats.dump-all) entries all=>snp_count and all=>indel_count).
 
-Next lets see how the variation is shared across the samples. 
+Next lets see how the variation is shared across the samples.
 ```{r echo=FALSE, message=FALSE, warning=FALSE, comment=NA}
 result <- DisplayAndDispatchQuery("../../sql/reproducing-vcfstats/shared-variant-counts-brca1.sql")
 ```
@@ -138,7 +137,7 @@ result <- DisplayAndDispatchQuery("../../sql/reproducing-vcfstats/snp-variant-co
 ```{r echo=FALSE, message=FALSE, warning=FALSE, comment=NA, results="asis"}
 print(xtable(result), type="html", include.rownames=F)
 ```
-We can see that some variants such as C->T are much more common than others such as T->G (equivalent to vcf-stats [dump-all](./vcfstats-output/stats.dump-all) entry all=>snp).  
+We can see that some variants such as C->T are much more common than others such as T->G (equivalent to vcf-stats [dump-all](./vcfstats-output/stats.dump-all) entry all=>snp).
 
 Note that in this data we have variants that are not present in any of the samples.
 ```{r echo=FALSE, message=FALSE, warning=FALSE, comment=NA}
@@ -185,7 +184,7 @@ print(xtable(head(result)), type="html", include.rownames=F)
 ```
 We can see that some samples differ from the reference quite a bit in this region while others are quite similar (equivalent to vcf-stats [indels](./vcfstats-output/stats.indels))
 
-Another important statistic for quality control is the ratio of transitions vs. transversions in SNPs. 
+Another important statistic for quality control is the ratio of transitions vs. transversions in SNPs.
 ```{r echo=FALSE, message=FALSE, warning=FALSE, comment=NA}
 result <- DisplayAndDispatchQuery("../../sql/reproducing-vcfstats/ti-tv-ratio-brca1.sql")
 ```

--- a/1000genomes/data-stories/understanding-alternate-alleles/README.Rmd
+++ b/1000genomes/data-stories/understanding-alternate-alleles/README.Rmd
@@ -25,12 +25,11 @@ require(ggplot2)
 require(dplyr)
 require(xtable)
 require(testthat)
-billing_project <- "google.com:biggene" # put your projectID here
+project <- "google.com:biggene" # put your projectID here
 DisplayAndDispatchQuery <- function(queryUri) {
   sql <- readChar(queryUri, nchars=1e6)
   cat(sql)
-  query_exec(project="google.com:biggene", dataset="1000genomes",
-                    query=sql, billing=billing_project)  
+  query_exec(sql, project)
 }
 ```
 
@@ -45,7 +44,7 @@ We see the first six tabular results:
 ```{r echo=FALSE, message=FALSE, warning=FALSE, comment=NA, results="asis"}
 print(xtable(head(result)), type="html", include.rownames=F)
 ```
-So we see from the data that the answer to our question is “No”.  
+So we see from the data that the answer to our question is “No”.
 
 So how many rows might we see per (contig, position, reference_bases) tuple?
 ```{r echo=FALSE, message=FALSE, warning=FALSE, comment=NA}
@@ -63,16 +62,16 @@ result <- DisplayAndDispatchQuery("../../sql/understanding-alternate-alleles/thr
 ```{r echo=FALSE, message=FALSE, warning=FALSE, comment=NA, results="asis"}
 print(xtable(result), type="html", include.rownames=F)
 ```
-From this small sample, it appears that the alternate allele is either a SNP or an INDEL.  
+From this small sample, it appears that the alternate allele is either a SNP or an INDEL.
 
-Is that the case for all the records corresponding to duplicate (contig, position, reference_bases) tuples?  
+Is that the case for all the records corresponding to duplicate (contig, position, reference_bases) tuples?
 ```{r echo=FALSE, message=FALSE, warning=FALSE, comment=NA}
 result <- DisplayAndDispatchQuery("../../sql/understanding-alternate-alleles/count-by-var-type-chrom-pos-ref-dups.sql")
 ```
 ```{r echo=FALSE, message=FALSE, warning=FALSE, comment=NA, results="asis"}
 print(xtable(result), type="html", include.rownames=F)
 ```
-It appears that for all records for duplicate (contig, position, reference_bases) tuples that we have a SNP and also an INDEL or SV.  
+It appears that for all records for duplicate (contig, position, reference_bases) tuples that we have a SNP and also an INDEL or SV.
 
 For records corresponding to a unique (contig, position, reference_bases) tuple, are the variants always SNPs?
 ```{r echo=FALSE, message=FALSE, warning=FALSE, comment=NA}
@@ -111,7 +110,7 @@ The [likelihoods](http://faculty.washington.edu/browning/beagle/intro-to-vcf.htm
 
 So a question for our users who have much experience in this domain, which variant is more likely for the second allele of HG00100?
 
-### But we digress . . . 
+### But we digress . . .
 
 Our original question was _“Is (contig, position, reference_bases) a unique key in the 1,000 Genomes Data?”_ which we know is false.  So which columns do constitute a unique key?
 

--- a/pgp/README.Rmd
+++ b/pgp/README.Rmd
@@ -31,12 +31,11 @@ require(ggplot2)
 require(dplyr)
 require(xtable)
 require(testthat)
-billing_project <- "google.com:biggene" # put your projectID here
+project <- "google.com:biggene" # put your projectID here
 DisplayAndDispatchQuery <- function(queryUri) {
   sql <- readChar(queryUri, nchars=1e6)
   cat(sql)
-  query_exec(project="google.com:biggene", dataset="1000genomes",
-                    query=sql, billing=billing_project)  
+  query_exec(sql, project)
 }
 ```
 

--- a/pgp/data-stories/comparing-pgp-to-1000genomes/README.Rmd
+++ b/pgp/data-stories/comparing-pgp-to-1000genomes/README.Rmd
@@ -25,12 +25,11 @@ require(ggplot2)
 require(dplyr)
 require(xtable)
 require(testthat)
-billing_project <- "google.com:biggene" # put your projectID here
+project <- "google.com:biggene" # put your projectID here
 DisplayAndDispatchQuery <- function(queryUri) {
   sql <- readChar(queryUri, nchars=1e6)
   cat(sql)
-  query_exec(project="google.com:biggene", dataset="1000genomes",
-                    query=sql, billing=billing_project)  
+  query_exec(sql, project)
 }
 ```
 
@@ -49,10 +48,10 @@ print(xtable(head(result), digits=6), type="html", include.rownames=F)
 
 ```{r variant counts, echo=FALSE, message=FALSE, warning=FALSE, comment=NA, fig.align="center", fig.width=12, fig.height=8}
 result$contig_name <- factor(result$contig_name, levels=c(as.character(seq(1,22)), "X", "Y", "M"))
-ggplot(result, aes(x=contig_name, y=cnt, fill=dataset)) + 
+ggplot(result, aes(x=contig_name, y=cnt, fill=dataset)) +
   geom_bar(stat="identity", position="dodge") +
   ylab("Number of variants") +
-  xlab("Chromosome") + 
+  xlab("Chromosome") +
   ggtitle("Total Variant Count by Chromosome")
 ```
 We see that the PGP dataset has more variants for all chromosomes except X.
@@ -70,24 +69,24 @@ print(xtable(head(result), digits=6), type="html", include.rownames=F)
 
 ```{r variant type counts, echo=FALSE, message=FALSE, warning=FALSE, comment=NA, fig.align="center", fig.width=12, fig.height=8}
 result$contig_name <- factor(result$contig_name, levels=c(as.character(seq(1,22)), "X", "Y", "M"))
-ggplot(result, aes(x=contig_name, y=cnt, fill=vt)) + 
+ggplot(result, aes(x=contig_name, y=cnt, fill=vt)) +
   geom_bar(stat="identity", position="dodge") +
   facet_grid(dataset ~ .) +
   scale_y_log10() +
   ylim(c(0, 3200000)) +
   ylab("Number of variants (log scale)") +
-  xlab("Chromosome") + 
+  xlab("Chromosome") +
   ggtitle("Total Variant Count by Chromosome and Type")
 ```
-In 1,000 Genomes the vast majority of variants are SNPs but the PGP dataset is much more diverse.  
+In 1,000 Genomes the vast majority of variants are SNPs but the PGP dataset is much more diverse.
 
 Re-plotting the data to just show the PGP variants:
 ```{r pgp variant type counts, echo=FALSE, message=FALSE, warning=FALSE, comment=NA, fig.align="center", fig.width=12, fig.height=8}
 result$contig_name <- factor(result$contig_name, levels=c(as.character(seq(1,22)), "X", "Y", "M"))
-ggplot(result[result$dataset == 'PGP',], aes(x=contig_name, y=cnt, fill=vt)) + 
+ggplot(result[result$dataset == 'PGP',], aes(x=contig_name, y=cnt, fill=vt)) +
   geom_bar(stat="identity", position="dodge") +
   ylab("Number of variants") +
-  xlab("Chromosome") + 
+  xlab("Chromosome") +
   ggtitle("Total Variant Count by Chromosome and Type")
 ```
 We can see that for PGP the proportion of indels is much higher and we have many more structural variants than in 1,000 Genomes.
@@ -130,14 +129,14 @@ ggplot(result) +
   scale_fill_gradient("Number of Variants", trans = "log", labels=function(x){round(x)}) +
   facet_grid(dataset ~ .) +
   ylab("Second Allele") +
-  xlab("First Allele") + 
+  xlab("First Allele") +
   ggtitle("Heatmaps of PGP and 1,000 Genomes genotypes")
 
 ```
 The two most notable aspects of these heatmaps is that PGP (unlike 1,000 Genomes)
  1. does have some variants with more than one alternate allele
  1. contains no genotypes that match the reference but note that this difference is an artifact of how the data was converted to VCF format (see [provenance](../../provenance) for more detail).  The native Complete Genomics files explicitly call most of the genome as "matching reference".
- 
+
 Next let us examine the upper and lower bounds on the number of samples per variant:
 ```{r echo=FALSE, message=FALSE, warning=FALSE, comment=NA, cache=FALSE}
 result <- DisplayAndDispatchQuery("../../sql/comparing-pgp-to-1000genomes/sample-counts-minmax-by-chromosome.sql")

--- a/pgp/data-stories/issues-with-the-variant-centric-approach/README.Rmd
+++ b/pgp/data-stories/issues-with-the-variant-centric-approach/README.Rmd
@@ -259,12 +259,11 @@ require(ggplot2)
 require(dplyr)
 require(xtable)
 require(testthat)
-billing_project <- "google.com:biggene" # put your projectID here
+project <- "google.com:biggene" # put your projectID here
 DisplayAndDispatchQuery <- function(queryUri) {
   sql <- readChar(queryUri, nchars=1e6)
   cat(sql)
-  query_exec(project="google.com:biggene", dataset="1000genomes",
-                    query=sql, billing=billing_project)  
+  query_exec(sql, project)
 }
 ```
 

--- a/pgp/data-stories/schema-comparisons/README.Rmd
+++ b/pgp/data-stories/schema-comparisons/README.Rmd
@@ -21,18 +21,17 @@ require(ggplot2)
 require(dplyr)
 require(xtable)
 require(testthat)
-billing_project <- "google.com:biggene" # put your projectID here
+project <- "google.com:biggene" # put your projectID here
 DisplayAndDispatchQuery <- function(queryUri) {
   sql <- readChar(queryUri, nchars=1e6)
   cat(sql)
-  query_exec(project="google.com:biggene", dataset="1000genomes",
-                    query=sql, billing=billing_project)  
+  query_exec(sql, project)
 }
 ```
 
 To determine how to improve the usability of the data and the schemas, we have the same data encoded several different ways, to compare and contrast querying each.
 
-Table      | Table Size | Description 
+Table      | Table Size | Description
 :------------- |:---------------:|:---------------
 [cgi_variants](../../provenance#cgi_variants-table)  |433GB | data from 174 CGI masterVar files in a flat schema (one row per sample) with reference matching blocks
 [gvcf_variants](../../provenance#gvcf_variants-table)  | 231GB | CGI data for 172 individuals converted to gVCF in a nested schema (per-sample data is nested) with reference matching blocks
@@ -41,8 +40,8 @@ Table      | Table Size | Description
 ```{r echo=FALSE}
 library(dplyr)
 
-count_lines <- function(path) { 
-    if(!is.na(path)) { 
+count_lines <- function(path) {
+    if(!is.na(path)) {
       length(readLines(path))
       }
     else {
@@ -67,7 +66,7 @@ obs <- mutate(observations,
 print(xtable(obs %.%
                filter(code == 'klotho.sql') %.%
                select(table_link, code_link, runtime, data_processed, line_count, notes),
-             digits=6), 
+             digits=6),
       type="html",
       include.rownames=F,
       sanitize.text.function=force)
@@ -78,7 +77,7 @@ print(xtable(obs %.%
 print(xtable(obs %.%
                filter(code == 'ti-tv-ratio.sql') %.%
                select(table_link, code_link, runtime, data_processed, line_count, notes),
-             digits=6), 
+             digits=6),
       type="html",
       include.rownames=F,
       sanitize.text.function=force)
@@ -89,7 +88,7 @@ print(xtable(obs %.%
 print(xtable(obs %.%
                filter(code == 'allelic-frequency-brca1.sql') %.%
                select(table_link, code_link, runtime, data_processed, line_count, notes),
-             digits=6), 
+             digits=6),
       type="html",
       include.rownames=F,
       sanitize.text.function=force)
@@ -100,7 +99,7 @@ print(xtable(obs %.%
 print(xtable(obs %.%
                filter(code == 'allele-count.sql') %.%
                select(table_link, code_link, runtime, data_processed, line_count, notes),
-             digits=6), 
+             digits=6),
       type="html",
       include.rownames=F,
       sanitize.text.function=force)
@@ -111,7 +110,7 @@ print(xtable(obs %.%
 print(xtable(obs %.%
                filter(code == 'allelic-frequency-chr1.sql') %.%
                select(table_link, code_link, runtime, data_processed, line_count, notes),
-             digits=6), 
+             digits=6),
       type="html",
       include.rownames=F,
       sanitize.text.function=force)
@@ -122,7 +121,7 @@ print(xtable(obs %.%
 print(xtable(obs %.%
                filter(code == 'allelic-frequency.sql') %.%
                select(table_link, code_link, runtime, data_processed, line_count, notes),
-             digits=6), 
+             digits=6),
       type="html",
       include.rownames=F,
       sanitize.text.function=force)
@@ -133,7 +132,7 @@ print(xtable(obs %.%
 print(xtable(obs %.%
                filter(code == 'allelic-frequency-comparison.sql') %.%
                select(table_link, code_link, runtime, data_processed, line_count, notes),
-             digits=6), 
+             digits=6),
       type="html",
       include.rownames=F,
       sanitize.text.function=force)
@@ -216,18 +215,18 @@ print(xtable(head(result, n=8)), type="html", include.rownames=F)
 And visually:
 ```{r variant_cnt, echo=FALSE, message=FALSE, warning=FALSE, comment=NA, fig.align="center", fig.width=8, fig.height=8}
 result$chromosome <- factor(result$chromosome, levels=c(as.character(seq(1,22)), "X", "Y", "M"))
-ggplot(filter(result, dataset != 'cgi_variants'), aes(x=chromosome, y=num_variants, fill=dataset)) + 
+ggplot(filter(result, dataset != 'cgi_variants'), aes(x=chromosome, y=num_variants, fill=dataset)) +
   geom_bar(stat="identity", position="dodge") +
   coord_flip() +
   xlab("Chromosome") +
-  ylab("Count of Variants") 
+  ylab("Count of Variants")
 ```
 ```{r call_cnt, echo=FALSE, message=FALSE, warning=FALSE, comment=NA, fig.align="center", fig.width=8, fig.height=8}
-ggplot(filter(result, dataset != 'cgi_variants'), aes(x=chromosome, y=num_records, fill=dataset)) + 
+ggplot(filter(result, dataset != 'cgi_variants'), aes(x=chromosome, y=num_records, fill=dataset)) +
   geom_bar(stat="identity", position="dodge") +
   coord_flip() +
   xlab("Chromosome") +
-  ylab("Count of Records (Variant-Calls, Ref-Calls, No-Calls)") 
+  ylab("Count of Records (Variant-Calls, Ref-Calls, No-Calls)")
 ```
 
 Let's also confirm with a few tests:
@@ -305,10 +304,10 @@ result$dataset <- factor(result$dataset, levels=c("cgi_variants",
                                                   "variants",
                                                   "gvcf_variants",
                                                   "gvcf_variants_expanded"))
-ggplot(result, aes(x=num_variant_alleles)) + 
+ggplot(result, aes(x=num_variant_alleles)) +
   geom_histogram() +
   facet_wrap(~ dataset) +
-  xlab("Count of Variant Alleles per Sample") 
+  xlab("Count of Variant Alleles per Sample")
 ```
 
 ```{r sample_call_cnt, echo=FALSE, message=FALSE, warning=FALSE, comment=NA, fig.align="center", fig.width=8, fig.height=8}
@@ -316,10 +315,10 @@ result$dataset <- factor(result$dataset, levels=c("cgi_variants",
                                                   "variants",
                                                   "gvcf_variants",
                                                   "gvcf_variants_expanded"))
-ggplot(result, aes(x=num_records)) + 
+ggplot(result, aes(x=num_records)) +
   geom_histogram() +
   facet_wrap(~ dataset) +
-  xlab("Count of Records per Sample (Variant-Calls, Ref-Calls, No-Calls)") 
+  xlab("Count of Records per Sample (Variant-Calls, Ref-Calls, No-Calls)")
 ```
 
 


### PR DESCRIPTION
PTAL @deflaux (if you'd rather just make this update yourself, I can drop this PR.)

I recently made a change to the signature of the `query_exec` function in
`bigrquery` R package, which meant that all calls in the examples needed
updating. I've done that here, with a few notes/caveats:
- The previous syntax _forced_ you to use the `default_dataset` option, which
  isn't common in most BQ usage. In addition, it looks like all the examples
  have explicit `project:dataset.table` names, which is preferred anyway --
  so I've just dropped the extra arguments. If there's something more subtle
  going on that I didn't catch, let me know.
- I also renamed `billing_project` to `project` everywhere -- this matches
  both the (updated) `bigrquery` docs and the BigQuery docs more closely.
- I didn't update the `.md` files -- I did load up one and run it, but it
  looks like there were other changes unrelated to what I was up to that I
  was also picking up. I kept the output, and am happy to include it -- but I
  suspect it makes more sense to do them all at once.
- My editor removed trailing whitespace in all the files I touched; I can
  revert those chunks if you're worried about `git blame` noise.
