### PR TITLE
Update query to reflect correct formula used for het_hom_ratio.

### DIFF
--- a/1000genomes_phase3/README.md
+++ b/1000genomes_phase3/README.md
@@ -63,7 +63,7 @@ SELECT
   call.call_set_name,
   # Ratios.
   transitions_count / transversions_count AS ti_tv_ratio,
-  (het_RA_count + het_AA_count) / (hom_RR_count + hom_AA_count) AS het_hom_ratio,
+  (het_RA_count + 2 * het_AA_count) / hom_AA_count AS het_hom_ratio,
   insertion_count / deletion_count AS ins_del_ratio,
   # Call type counts.
   hom_RR_count,

--- a/1000genomes_phase3/sql/qc-metrics.sql
+++ b/1000genomes_phase3/sql/qc-metrics.sql
@@ -9,7 +9,7 @@ SELECT
   call.call_set_name,
   # Ratios.
   transitions_count / transversions_count AS ti_tv_ratio,
-  (het_RA_count + het_AA_count) / (hom_RR_count + hom_AA_count) AS het_hom_ratio,
+  (het_RA_count + 2 * het_AA_count) / hom_AA_count AS het_hom_ratio,
   insertion_count / deletion_count AS ins_del_ratio,
   # Call type counts.
   hom_RR_count,


### PR DESCRIPTION
This matches the query used to create tables google.com:biggene:1000genomes_analysis_results.phase3_metrics
and google.com:biggene:1000genomes_analysis_results.phase1_metrics

Change-Id: I36beee6e345abdfa3fb87e0cada36ccdf1c148e8